### PR TITLE
Added in missing cost basis and fixed column mismatch.

### DIFF
--- a/background.js
+++ b/background.js
@@ -18,7 +18,15 @@ chrome.contextMenus.create({
     id: "m1ToCSV-save",
     parentId: "m1ToCSV",
     title: "Save to CSV",
-    onclick: () => send("save"),
+    onclick: () => send("m1.save"),
+    documentUrlPatterns
+});
+
+chrome.contextMenus.create({
+    id: "m1ToCSV-save-ss",
+    parentId: "m1ToCSV",
+    title: "Save to CSV (Simply Safe compatible)",
+    onclick: () => send("ss.save"),
     documentUrlPatterns
 });
 
@@ -26,6 +34,14 @@ chrome.contextMenus.create({
     id: "m1ToCSV-copy",
     parentId: "m1ToCSV",
     title: "Copy to clipboard",
-    onclick: () => send("copy"),
+    onclick: () => send("m1.copy"),
+    documentUrlPatterns
+});
+
+chrome.contextMenus.create({
+    id: "m1ToCSV-copy-ss",
+    parentId: "m1ToCSV",
+    title: "Copy to clipboard (Simply Safe compatible)",
+    onclick: () => send("ss.copy"),
     documentUrlPatterns
 });

--- a/content.js
+++ b/content.js
@@ -9,10 +9,10 @@ function getData(joinRowsBy) {
     // First 3 lines of headers should not move, the order is to support simply safe dividends
     let headers = [
         "Ticker",
+        "Name",
         "Shares",
         "Avg. Price",
-        "Name",
-        "Maintenance",
+        "Cost Basis",
         "Unrealized Gain",
         "Unrealized Gain %",
         "Value"
@@ -53,6 +53,7 @@ function mapPositionValue(row, joinRowsBy) {
         name, // Main Street Capital Corp.
         shares, // 12.63455
         price, // $30.32
+        costBasis, // $380.00
         maintenance, // 45%
         _gain, // +$18.31 (▲4.78%)
         gain1, // +$18.31
@@ -65,10 +66,10 @@ function mapPositionValue(row, joinRowsBy) {
     return [
         // First 3 lines  should not move, the order is to support simply safe dividends
         ticker,
+        name,
         shares,
         price,
-        name,
-        maintenance,
+        costBasis,
         gain1,
         gain2,
         value


### PR DESCRIPTION
Fixes #1 

M1's holding tab:
<img width="1181" alt="Screen Shot 2020-09-11 at 12 32 25 AM" src="https://user-images.githubusercontent.com/6657259/92867970-d7ee1500-f3c6-11ea-8bca-03f6304b9762.png">

Current incorrect output:
<img width="923" alt="Screen Shot 2020-09-11 at 12 35 33 AM" src="https://user-images.githubusercontent.com/6657259/92868063-f0f6c600-f3c6-11ea-947b-09c98612e491.png">


Correct output from this PRs changes:
<img width="923" alt="Screen Shot 2020-09-11 at 12 33 36 AM" src="https://user-images.githubusercontent.com/6657259/92868019-e63c3100-f3c6-11ea-9183-ec5603b70c50.png">

- The 'Cost Basis' column wasn't present. It has been added.
- 'Maintenance' has been removed because it's not useful.
- 'Value' now correctly shows value.
- 'Unrealized Gain' and 'Unrealized Gain%' fixed to show correct values.

NOTE: This PR might cause issues with simply safe dividends. Based on the following comment in code:
```
        // First 3 lines  should not move, the order is to support simply safe dividends
```
If the first three values need to be names, shares, and price so that the data can be exported to simply safe, that would no longer work, because this PR sets the column order to match the column order in M1 Finance. I'd suggest that if we need to support Simply Safe, we add a 3rd/4th option that says 'Copy 'Simply Safe Compatible' to clipboard' and 'Save 'Simply Safe Compatible' to CSV'.